### PR TITLE
Fix clipboard image paste dispatch

### DIFF
--- a/clipboard/clipboard.py
+++ b/clipboard/clipboard.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 import os
 import sys
+import ctypes
 
 from locale import getdefaultlocale
 
@@ -11,6 +12,80 @@ import bpy
 
 TEMP_DIR = ''
 IMAGE_CREATE_TIME_COST = 1  # seconds
+
+SPACE_STATE_ATTRS = (
+    'tree_type',
+    'shader_type',
+    'geometry_nodes_type',
+)
+
+
+def _get_optional_attr(data, attr):
+    if not hasattr(data, attr):
+        return False, None
+    try:
+        return True, getattr(data, attr)
+    except Exception:
+        return False, None
+
+
+def _set_optional_attr(data, attr, value):
+    if not hasattr(data, attr):
+        return
+    try:
+        setattr(data, attr, value)
+    except Exception:
+        pass
+
+
+def _capture_area_state(area):
+    state = {
+        'type': area.type,
+        'space': {},
+    }
+
+    has_ui_type, ui_type = _get_optional_attr(area, 'ui_type')
+    if has_ui_type:
+        state['ui_type'] = ui_type
+
+    try:
+        space = area.spaces.active
+    except Exception:
+        space = None
+
+    if space is not None:
+        for attr in SPACE_STATE_ATTRS:
+            has_attr, value = _get_optional_attr(space, attr)
+            if has_attr and isinstance(value, str) and value:
+                state['space'][attr] = value
+
+    return state
+
+
+def _restore_area_state(area, state):
+    try:
+        if area.type != state['type']:
+            area.type = state['type']
+    except Exception:
+        return
+
+    if 'ui_type' in state:
+        _set_optional_attr(area, 'ui_type', state['ui_type'])
+
+    try:
+        space = area.spaces.active
+    except Exception:
+        return
+
+    for attr, value in state['space'].items():
+        _set_optional_attr(space, attr, value)
+
+
+def _can_paste_image_from_clipboard():
+    try:
+        return bpy.ops.image.clipboard_paste.poll()
+    except Exception:
+        return False
 
 
 def get_dir():
@@ -85,8 +160,7 @@ class Clipboard():
             res = CheckStringFile().is_something()
             if res:
                 file_list.append(res)
-
-            return file_list
+                return file_list
 
         # user is copying image bytes
         image_path = self.pull_image_from_clipboard()  # create image from clipboard
@@ -133,23 +207,26 @@ class Clipboard():
         if image_path:
             return image_path
 
+        if sys.platform == 'darwin':
+            return MacClipboard().pull_image_from_clipboard()
         if sys.platform == 'win32':
-            clipboard = PowerShellClipboard()
-        elif sys.platform == 'darwin':
-            clipboard = MacClipboard()
+            return PowerShellClipboard().pull_image_from_clipboard()
 
-        return clipboard.pull_image_from_clipboard()
+        return ''
 
     def pull_image_from_clipboard_with_blender(self, save_name='spio_from_clipboard.png'):
         area = bpy.context.area
         if area is None:
             return ''
 
-        old_area_type = area.type
+        old_area_state = _capture_area_state(area)
         old_images = set(bpy.data.images)
         try:
             if area.type != 'IMAGE_EDITOR':
                 area.type = 'IMAGE_EDITOR'
+
+            if not _can_paste_image_from_clipboard():
+                return ''
 
             result = bpy.ops.image.clipboard_paste()
             if result != {'FINISHED'}:
@@ -169,15 +246,17 @@ class Clipboard():
         except Exception:
             return ''
         finally:
-            if area.type != old_area_type:
-                area.type = old_area_type
+            _restore_area_state(area, old_area_state)
 
 
 class MacClipboard():
 
     def pull(self, force_unicode=False):
         self.file_urls = []
-        from .darwin import _native as pasteboard
+        try:
+            from .darwin import _native as pasteboard
+        except ImportError:
+            return self.pull_file_urls_with_osascript()
 
         pb = pasteboard.Pasteboard()
 
@@ -186,6 +265,33 @@ class MacClipboard():
         if urls is not None:
             self.file_urls = list(urls)
 
+        return self.file_urls
+
+    def pull_file_urls_with_osascript(self):
+        commands = [
+            'set filePaths to ""',
+            'try',
+            '    set clipboardItems to the clipboard as list',
+            '    repeat with clipboardItem in clipboardItems',
+            '        try',
+            '            set filePaths to filePaths & POSIX path of clipboardItem & linefeed',
+            '        end try',
+            '    end repeat',
+            'on error',
+            '    try',
+            '        set filePaths to POSIX path of (the clipboard as alias)',
+            '    end try',
+            'end try',
+            'return filePaths',
+        ]
+        popen = subprocess.Popen(
+            self.get_osascript_args(commands),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding='utf-8',
+        )
+        stdout, stderr = popen.communicate()
+        self.file_urls = [file for file in stdout.splitlines() if file]
         return self.file_urls
 
     def push_pixel_to_clipboard(self, path):
@@ -211,6 +317,10 @@ class MacClipboard():
         return args
 
     def pull_image_from_clipboard(self, save_name='spio_from_clipboard.png'):
+        filepath = self.pull_image_from_clipboard_with_cocoa(save_name)
+        if filepath:
+            return filepath
+
         ts = time.strftime('%Y_%m_%d_%H_%M_%S', time.localtime())
         filepath = os.path.join(get_dir(), ts + '.' + save_name)
 
@@ -226,6 +336,64 @@ class MacClipboard():
         stdout, stderr = popen.communicate()
 
         return filepath
+
+    def pull_image_from_clipboard_with_cocoa(self, save_name='spio_from_clipboard.png'):
+        try:
+            ctypes.cdll.LoadLibrary('/System/Library/Frameworks/AppKit.framework/AppKit')
+            objc = ctypes.cdll.LoadLibrary('/usr/lib/libobjc.A.dylib')
+            objc.objc_getClass.restype = ctypes.c_void_p
+            objc.objc_getClass.argtypes = [ctypes.c_char_p]
+            objc.sel_registerName.restype = ctypes.c_void_p
+            objc.sel_registerName.argtypes = [ctypes.c_char_p]
+
+            msg_send_addr = ctypes.cast(objc.objc_msgSend, ctypes.c_void_p).value
+            msg_id = ctypes.CFUNCTYPE(ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p)(msg_send_addr)
+            msg_id_id = ctypes.CFUNCTYPE(
+                ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p
+            )(msg_send_addr)
+            msg_id_cstr = ctypes.CFUNCTYPE(
+                ctypes.c_void_p, ctypes.c_void_p, ctypes.c_void_p, ctypes.c_char_p
+            )(msg_send_addr)
+            msg_ulong = ctypes.CFUNCTYPE(ctypes.c_ulong, ctypes.c_void_p, ctypes.c_void_p)(msg_send_addr)
+
+            ns_pasteboard = objc.objc_getClass(b'NSPasteboard')
+            ns_string = objc.objc_getClass(b'NSString')
+            pasteboard = msg_id(ns_pasteboard, objc.sel_registerName(b'generalPasteboard'))
+
+            pasteboard_types = (
+                ('public.png', 'png'),
+                ('Apple PNG pasteboard type', 'png'),
+                ('public.tiff', 'tiff'),
+                ('NeXT TIFF v4.0 pasteboard type', 'tiff'),
+            )
+            for pasteboard_type, extension in pasteboard_types:
+                ns_type = msg_id_cstr(
+                    ns_string,
+                    objc.sel_registerName(b'stringWithUTF8String:'),
+                    pasteboard_type.encode('utf-8'),
+                )
+                data = msg_id_id(pasteboard, objc.sel_registerName(b'dataForType:'), ns_type)
+                if not data:
+                    continue
+
+                length = msg_ulong(data, objc.sel_registerName(b'length'))
+                if length == 0:
+                    continue
+
+                bytes_ptr = msg_id(data, objc.sel_registerName(b'bytes'))
+                if not bytes_ptr:
+                    continue
+
+                ts = time.strftime('%Y_%m_%d_%H_%M_%S', time.localtime())
+                base_name, _ext = os.path.splitext(save_name)
+                filepath = os.path.join(get_dir(), f'{ts}.{base_name}.{extension}')
+                with open(filepath, 'wb') as f:
+                    f.write(ctypes.string_at(bytes_ptr, length))
+                return filepath
+        except Exception:
+            return ''
+
+        return ''
 
 
 class PowerShellClipboard:

--- a/clipboard/darwin/mac.py
+++ b/clipboard/darwin/mac.py
@@ -12,7 +12,10 @@ class MacClipboard():
 
     def pull(self, force_unicode=False):
         self.file_urls = []
-        from . import _native as pasteboard
+        try:
+            from . import _native as pasteboard
+        except ImportError:
+            return self.pull_file_urls_with_osascript()
 
         pb = pasteboard.Pasteboard()
 
@@ -21,6 +24,33 @@ class MacClipboard():
         if urls is not None:
             self.file_urls = list(urls)
 
+        return self.file_urls
+
+    def pull_file_urls_with_osascript(self):
+        commands = [
+            'set filePaths to ""',
+            'try',
+            '    set clipboardItems to the clipboard as list',
+            '    repeat with clipboardItem in clipboardItems',
+            '        try',
+            '            set filePaths to filePaths & POSIX path of clipboardItem & linefeed',
+            '        end try',
+            '    end repeat',
+            'on error',
+            '    try',
+            '        set filePaths to POSIX path of (the clipboard as alias)',
+            '    end try',
+            'end try',
+            'return filePaths',
+        ]
+        popen = subprocess.Popen(
+            self.get_osascript_args(commands),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            encoding='utf-8',
+        )
+        stdout, stderr = popen.communicate()
+        self.file_urls = [file for file in stdout.splitlines() if file]
         return self.file_urls
 
     def push_pixel_to_clipboard(self, path):

--- a/ops/core.py
+++ b/ops/core.py
@@ -13,6 +13,13 @@ def get_pref():
     return None
 
 
+def get_pref_attr(attr, default=None):
+    pref = get_pref()
+    if pref is None:
+        return default
+    return getattr(pref, attr, default)
+
+
 def viewlayer_fix_291(self, context):
     return context.view_layer.depsgraph
 
@@ -274,7 +281,7 @@ class PopupExportMenu():
             # col.separator()
             from ..imexporter.default_exporter import get_exporter, get_exporter_ops_props
             # get exporter by preferences
-            default_exporter = get_exporter(extend=get_pref().extend_export_menu)
+            default_exporter = get_exporter(extend=get_pref_attr('extend_export_menu', False))
             exporter_ops_props = get_exporter_ops_props()
 
             for ext, bl_idname in default_exporter.items():
@@ -296,6 +303,7 @@ class PopupImportMenu():
 
     def default_image_menu(self, return_menu=False):
         context = self.context
+        target_context = self.context
         join_paths = '$$'.join(self.file_list)
         join_dirs = '$$'.join(self.dir_list)
 
@@ -352,7 +360,7 @@ class PopupImportMenu():
                     op = col.operator('spio.import_image_as_nodes')
                     op.files = join_paths
 
-                    if context.area.ui_type == 'ShaderNodeTree':
+                    if target_context.area.ui_type == 'ShaderNodeTree':
                         col = layout.column()
                         op = col.operator('spio.import_image_pbr_setup')
                         op.files = join_paths
@@ -478,7 +486,7 @@ class PostProcess():
         post_process_blend_file(filepath, scripts_file_name)
 
     def open_dir(self, temp_dir):
-        if get_pref().post_open_dir:
+        if get_pref_attr('post_open_dir', False):
             bpy.ops.wm.path_open(filepath=temp_dir)
 
     @staticmethod
@@ -493,7 +501,7 @@ class PostProcess():
 
     def copy_to_clipboard(self, paths, op):
         """Win only now, need to test mac"""
-        if get_pref().post_push_to_clipboard:
+        if get_pref_attr('post_push_to_clipboard', True):
 
             from ..clipboard.clipboard import Clipboard as Clipboard
 

--- a/ops/dynamic_io.py
+++ b/ops/dynamic_io.py
@@ -9,7 +9,7 @@ from bpy.props import (EnumProperty,
                        IntProperty,
                        BoolProperty)
 
-from .core import get_pref, MeasureTime, PostProcess
+from .core import get_pref_attr, MeasureTime, PostProcess
 
 
 class IO_Base(bpy.types.Operator):
@@ -49,8 +49,8 @@ class IO_Base(bpy.types.Operator):
             bpy.utils.unregister_class(cls)
 
     def report_time(self, start_time):
-        if get_pref().report_time: self.report({"INFO"},
-                                               f'{self.bl_label} Cost {round(time.time() - start_time, 5)} s')
+        if get_pref_attr('report_time', True): self.report({"INFO"},
+                                                           f'{self.bl_label} Cost {round(time.time() - start_time, 5)} s')
 
     # Import Method
     def import_blend_default(self, context):
@@ -95,8 +95,8 @@ class DynamicImport:
                     except Exception as e:
                         self.report({"ERROR"}, str(e))
 
-                if get_pref().report_time: self.report({"INFO"},
-                                                       f'{self.bl_label} Cost {round(time.time() - start_time, 5)} s')
+                if get_pref_attr('report_time', True): self.report({"INFO"},
+                                                                   f'{self.bl_label} Cost {round(time.time() - start_time, 5)} s')
         else:
             self.report({"ERROR"}, f'{op_callable} Error!!!')
 
@@ -199,8 +199,8 @@ class DynamicExport:
                 POST.copy_to_clipboard(paths=PostProcess.get_update_files(src_file, temp_dir), op=self)
                 POST.open_dir(temp_dir)
 
-                if get_pref().report_time: self.report({"INFO"},
-                                                       f'{self.bl_label} Cost {round(time.time() - start_time, 5)} s')
+                if get_pref_attr('report_time', True): self.report({"INFO"},
+                                                                   f'{self.bl_label} Cost {round(time.time() - start_time, 5)} s')
         else:
             self.report({"ERROR"}, f'{op_callable} Error!!!')
 

--- a/ops/op_image_io.py
+++ b/ops/op_image_io.py
@@ -6,6 +6,11 @@ from bpy.props import StringProperty, BoolProperty, EnumProperty
 
 from ..public_path_utils import get_template_dir, TemplateDir
 
+NODE_IMAGE_NODE_TYPES = {
+    'CompositorNodeTree': 'CompositorNodeImage',
+    'GeometryNodeTree': 'GeometryNodeImageTexture',
+}
+
 
 class image_io:
     bl_options = {'UNDO_GROUPED'}
@@ -21,10 +26,14 @@ class image_io:
                     and context.mode == "OBJECT")
 
         elif context.area.type == "NODE_EDITOR":
+            space_data = getattr(context, 'space_data', None)
+            if getattr(context.area, 'ui_type', '') == 'CompositorNodeTree':
+                return getattr(context, 'scene', None) is not None
+
             return (
                     context.area.type == "NODE_EDITOR"
                     and context.area.ui_type in {'GeometryNodeTree', "ShaderNodeTree", 'CompositorNodeTree'}
-                    and context.space_data.edit_tree is not None
+                    and get_node_tree(space_data, context) is not None
             )
         elif context.area.type == 'FILE_BROWSER':
             return context.area.ui_type == 'ASSETS'
@@ -41,6 +50,85 @@ class image_io:
         image = images[0]
 
         return image
+
+
+def load_image_data_by_path(path):
+    try:
+        return bpy.data.images.load(path, check_existing=True)
+    except RuntimeError:
+        image = bpy.data.images.get(os.path.basename(path))
+        if image is None:
+            raise
+        image.reload()
+        return image
+
+
+def get_compositor_node_tree(context, create=False):
+    scene = getattr(context, 'scene', None)
+    if scene is None:
+        return None
+
+    tree = getattr(scene, 'node_tree', None)
+    if tree is not None:
+        return tree
+
+    tree = getattr(scene, 'compositing_node_group', None)
+    if tree is not None:
+        return tree
+
+    if not create:
+        return None
+
+    if hasattr(scene, 'use_nodes'):
+        try:
+            scene.use_nodes = True
+        except Exception:
+            pass
+        tree = getattr(scene, 'node_tree', None) or getattr(scene, 'compositing_node_group', None)
+        if tree is not None:
+            return tree
+
+    if hasattr(scene, 'compositing_node_group'):
+        tree = bpy.data.node_groups.new('Compositing Nodes', 'CompositorNodeTree')
+        scene.compositing_node_group = tree
+        return tree
+
+    return None
+
+
+def get_node_tree(space_data, context=None, create=False):
+    if space_data is None:
+        return None
+
+    for attr in ('edit_tree', 'node_tree'):
+        tree = getattr(space_data, attr, None)
+        if tree is not None:
+            return tree
+
+    if context is not None and getattr(context.area, 'ui_type', '') == 'CompositorNodeTree':
+        return get_compositor_node_tree(context, create=create)
+
+    return None
+
+
+def get_image_node_type(context):
+    ui_type = getattr(context.area, 'ui_type', '')
+    if ui_type == 'ShaderNodeTree':
+        shader_type = getattr(context.space_data, 'shader_type', '')
+        if shader_type == 'WORLD':
+            return 'ShaderNodeTexEnvironment'
+        return 'ShaderNodeTexImage'
+
+    return NODE_IMAGE_NODE_TYPES.get(ui_type)
+
+
+def assign_image_to_node(node, image):
+    if hasattr(node, 'image'):
+        node.image = image
+        return
+
+    if hasattr(node, 'inputs') and 'Image' in node.inputs:
+        node.inputs['Image'].default_value = image
 
 
 class SPIO_OT_import_image_as_reference(image_io, bpy.types.Operator):
@@ -74,22 +162,18 @@ class SPIO_OT_import_image_as_nodes(image_io, bpy.types.Operator):
     bl_label = "Import as Nodes"
 
     def execute(self, context):
-        location_X, location_Y = context.space_data.cursor_location
+        nt = get_node_tree(context.space_data, context, create=True)
+        node_type = get_image_node_type(context)
+        if nt is None or node_type is None:
+            self.report({'ERROR'}, 'No supported node tree found')
+            return {'CANCELLED'}
+
+        location_X, location_Y = getattr(context.space_data, 'cursor_location', (0, 0))
         for filepath in self.files.split('$$'):
             image = self.load_image_by_path(filepath)
 
-            bpy.ops.node.select_all(action='DESELECT')
-            nt = context.space_data.edit_tree
-
-            if context.area.ui_type == 'ShaderNodeTree':
-                if context.space_data.shader_type == 'WORLD':
-                    node_type = 'ShaderNodeTexEnvironment'
-                else:
-                    node_type = 'ShaderNodeTexImage'
-            elif context.area.ui_type == 'GeometryNodeTree':
-                node_type = 'GeometryNodeImageTexture'
-            elif context.area.ui_type == 'CompositorNodeTree':
-                node_type = 'CompositorNodeImage'
+            for node in nt.nodes:
+                node.select = False
 
             tex_node = nt.nodes.new(node_type)
             tex_node.location = location_X, location_Y
@@ -100,10 +184,7 @@ class SPIO_OT_import_image_as_nodes(image_io, bpy.types.Operator):
             tex_node.select = True
             nt.nodes.active = tex_node
 
-            if node_type in {'ShaderNodeTexImage', 'ShaderNodeTexEnvironment', 'CompositorNodeImage'}:
-                tex_node.image = image
-            elif node_type == 'GeometryNodeImageTexture':
-                tex_node.inputs['Image'].default_value = image
+            assign_image_to_node(tex_node, image)
 
         return {'FINISHED'}
 

--- a/ops/op_model_export.py
+++ b/ops/op_model_export.py
@@ -4,7 +4,7 @@ import sys
 
 from bpy.props import StringProperty, BoolProperty, EnumProperty
 
-from .core import get_pref, PostProcess
+from .core import get_pref_attr, PostProcess
 
 
 class ModeCopyDefault:
@@ -80,7 +80,7 @@ class SPIO_OT_export_model(ModeCopyDefault, bpy.types.Operator):
 
         from ..imexporter.default_exporter import get_exporter, get_exporter_ops_props
         # get exporter by preferences
-        default_exporter = get_exporter(extend=get_pref().extend_export_menu)
+        default_exporter = get_exporter(extend=get_pref_attr('extend_export_menu', False))
         exporter_ops_props = get_exporter_ops_props()
 
         if self.extension not in default_exporter: return {"CANCELLED"}

--- a/ops/ops_super_import.py
+++ b/ops/ops_super_import.py
@@ -8,10 +8,44 @@ from bpy.props import (StringProperty)
 
 from .dynamic_io import IO_Base
 from .core import MeasureTime, ConfigItemHelper, ConfigHelper
-from .core import get_pref
+from .core import get_pref_attr
 
 from ..preferences.data_icon import G_ICON_ID
 from ..preferences.data_config_store import get_config_list
+
+
+def capture_dispatch_context(context):
+    return {
+        'window': getattr(context, 'window', None),
+        'screen': getattr(context, 'screen', None),
+        'area': getattr(context, 'area', None),
+        'region': getattr(context, 'region', None),
+    }
+
+
+def run_in_dispatch_context(context, dispatch_context, callback):
+    override = {key: value for key, value in dispatch_context.items() if value is not None}
+    if not override:
+        return callback(context)
+
+    try:
+        override_context = context.temp_override(**override)
+    except Exception:
+        return callback(context)
+
+    try:
+        override_context.__enter__()
+    except Exception:
+        return callback(context)
+
+    try:
+        result = callback(bpy.context)
+    except Exception:
+        override_context.__exit__(*sys.exc_info())
+        raise
+    else:
+        override_context.__exit__(None, None, None)
+        return result
 
 
 class SuperImport(IO_Base, bpy.types.Operator):
@@ -23,17 +57,20 @@ class SuperImport(IO_Base, bpy.types.Operator):
     ############
     def invoke(self, context, event):
         self.restore()
+        dispatch_context = capture_dispatch_context(context)
 
         from ..clipboard.clipboard import Clipboard as Clipboard
         # get Clipboard
         self.clipboard = Clipboard()
-        file_list = self.clipboard.pull_files_from_clipboard(force_unicode=get_pref().force_unicode)
+        file_list = self.clipboard.pull_files_from_clipboard(
+            force_unicode=get_pref_attr('force_unicode', False)
+        )
 
         del self.clipboard  # release clipboard
 
         if len(file_list) == 0:
             self.report({"ERROR"}, "No file found in clipboard!")
-            return {"CANCELLED"}
+            return {"FINISHED"}
 
         for file_path in file_list:
             if os.path.isdir(file_path):
@@ -76,14 +113,14 @@ class SuperImport(IO_Base, bpy.types.Operator):
             self.use_custom_config = False
 
             if self.ext == 'blend':
-                self.import_blend_default(context)
+                run_in_dispatch_context(context, dispatch_context, self.import_blend_default)
                 return {'FINISHED'}
             else:
-                return self.execute(context)
+                return run_in_dispatch_context(context, dispatch_context, self.execute)
 
         self.use_custom_config = True
 
-        return self.import_custom_dynamic(context)
+        return run_in_dispatch_context(context, dispatch_context, self.import_custom_dynamic)
 
     def execute(self, context):
         with MeasureTime() as start_time:
@@ -171,7 +208,7 @@ class SuperImport(IO_Base, bpy.types.Operator):
                     except Exception as e:
                         self.report({"ERROR"}, str(e))
 
-                if get_pref().report_time: self.report_time(start_time)
+                if get_pref_attr('report_time', True): self.report_time(start_time)
 
         # then popup menu to select the remain not matching file
         remain_list = list()
@@ -194,6 +231,7 @@ class SuperImport(IO_Base, bpy.types.Operator):
             from .core import PopupImportMenu
             import_op = self
             ext = self.ext
+            target_context = context
 
             def draw_custom_menu(self, context):
                 layout = self.layout
@@ -212,15 +250,15 @@ class SuperImport(IO_Base, bpy.types.Operator):
                 elif ext == 'blend':
                     pop = PopupImportMenu(file_list=remain_list,
                                           dir_list=dir_list,
-                                          context=context)
+                                          context=target_context)
                     menu = pop.default_blend_menu(return_menu=True)
-                    if menu: menu(self, context)
+                    if menu: menu(self, target_context)
                 else:
                     pop = PopupImportMenu(file_list=remain_list,
                                           dir_list=dir_list,
-                                          context=context)
+                                          context=target_context)
                     menu = pop.default_image_menu(return_menu=True)
-                    if menu: menu(self, context)
+                    if menu: menu(self, target_context)
 
             context.window_manager.popup_menu(draw_custom_menu, title=title, icon='FILEBROWSER')
 

--- a/preferences/data_keymap.py
+++ b/preferences/data_keymap.py
@@ -1,38 +1,44 @@
 import bpy
+import sys
 
 addon_keymaps = []
+
+
+def add_keymap_item(km, idname, key, value, **modifiers):
+    kmi = km.keymap_items.new(idname, key, value, **modifiers)
+    addon_keymaps.append((km, kmi))
+
+    if sys.platform == 'darwin' and modifiers.get('ctrl'):
+        oskey_modifiers = modifiers.copy()
+        oskey_modifiers['ctrl'] = False
+        oskey_modifiers['oskey'] = True
+        kmi = km.keymap_items.new(idname, key, value, **oskey_modifiers)
+        addon_keymaps.append((km, kmi))
 
 
 def register():
     wm = bpy.context.window_manager
     if wm.keyconfigs.addon:
         km = wm.keyconfigs.addon.keymaps.new(name='3D View', space_type='VIEW_3D')
-        kmi = km.keymap_items.new("wm.super_import", 'V', 'PRESS', ctrl=True, shift=True)
-        addon_keymaps.append((km, kmi))
+        add_keymap_item(km, "wm.super_import", 'V', 'PRESS', ctrl=True, shift=True)
 
         km = wm.keyconfigs.addon.keymaps.new(name='Node Editor', space_type='NODE_EDITOR')
-        kmi = km.keymap_items.new("wm.super_import", 'V', 'PRESS', ctrl=True, shift=True)
-        addon_keymaps.append((km, kmi))
+        add_keymap_item(km, "wm.super_import", 'V', 'PRESS', ctrl=True, shift=True)
 
         km = wm.keyconfigs.addon.keymaps.new(name='Node Editor', space_type='NODE_EDITOR')
-        kmi = km.keymap_items.new("wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
-        addon_keymaps.append((km, kmi))
+        add_keymap_item(km, "wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
 
         km = wm.keyconfigs.addon.keymaps.new(name='Image Generic', space_type='IMAGE_EDITOR')
-        kmi = km.keymap_items.new("wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
-        addon_keymaps.append((km, kmi))
+        add_keymap_item(km, "wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
 
         km = wm.keyconfigs.addon.keymaps.new(name='3D View', space_type='VIEW_3D')
-        kmi = km.keymap_items.new("wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
-        addon_keymaps.append((km, kmi))
+        add_keymap_item(km, "wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
 
         km = wm.keyconfigs.addon.keymaps.new(name='File Browser', space_type='FILE_BROWSER')
-        kmi = km.keymap_items.new("wm.super_import", 'V', 'PRESS', ctrl=True, shift=True)
-        addon_keymaps.append((km, kmi))
+        add_keymap_item(km, "wm.super_import", 'V', 'PRESS', ctrl=True, shift=True)
 
         km = wm.keyconfigs.addon.keymaps.new(name='File Browser', space_type='FILE_BROWSER')
-        kmi = km.keymap_items.new("wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
-        addon_keymaps.append((km, kmi))
+        add_keymap_item(km, "wm.super_export", 'C', 'PRESS', ctrl=True, shift=True)
 
 
 def unregister():

--- a/ui/ui_panel.py
+++ b/ui/ui_panel.py
@@ -19,10 +19,16 @@ class SidebarSetup:
 class SPIO_PT_PrefPanel(SidebarSetup, bpy.types.Panel):
     bl_label = ''
 
+    @classmethod
+    def poll(cls, context):
+        return get_pref() is not None
+
     def draw_header(self, context):
         layout = self.layout
         layout.alignment = "LEFT"
         pref = get_pref()
+        if pref is None:
+            return
 
         row = layout
         row = row.row(align=True)
@@ -34,6 +40,10 @@ class SPIO_PT_PrefPanel(SidebarSetup, bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         pref = get_pref()
+        if pref is None:
+            layout.label(text='Super IO preferences unavailable', icon='ERROR')
+            return
+
         if pref.ui == 'SETTINGS':
             SPIO_Preference.draw_settings(pref, context, layout)
         elif pref.ui == 'CONFIG':
@@ -68,7 +78,8 @@ class SPIO_PT_AssetHelper(SidebarSetup, bpy.types.Panel):
 
     @classmethod
     def poll(self, context):
-        return get_pref().asset_helper
+        pref = get_pref()
+        return pref is not None and pref.asset_helper
 
     def draw(self, context):
         layout = self.layout
@@ -112,4 +123,3 @@ def unregister():
     bpy.utils.unregister_class(SPIO_PT_PrefPanel_Main)
     bpy.utils.unregister_class(SPIO_PT_ImportPanel)
     bpy.utils.unregister_class(SPIO_PT_AssetHelper)
-


### PR DESCRIPTION
## Summary

Fixes #59.
Fixes #52.

This PR fixes Super IO image-pixel paste dispatch across Blender editor contexts. The core fix is cross-platform: pasted image payloads are routed back through the original editor context, and image nodes are created with the correct node type for each supported node editor.

It also fixes the macOS `_native` pasteboard import failure shown in #52 by falling back to AppleScript file URL reads when the compiled native pasteboard module is unavailable.

Some clipboard fallback details are platform-specific. Blender's own `bpy.ops.image.clipboard_paste()` is still attempted first; if that path fails, the existing platform fallback layer is used. This PR adds a macOS Cocoa PNG/TIFF fallback because Blender 5.1.2 on macOS can return `CANCELLED` even when `clipboard_paste.poll()` returns true.

## What Changed

- Preserve and restore editor state while probing Blender's image clipboard paste path.
- Route pasted image pixels back through the original dispatch context instead of the temporary Image Editor context.
- Create the correct image node type for Shader, World Shader, Geometry Nodes, and Compositor nodes.
- Keep platform fallback behavior for image-pixel clipboard extraction:
  - macOS: Blender paste first, then Cocoa PNG/TIFF pasteboard fallback.
  - Windows: Blender paste first, then the existing PowerShell image fallback.
- Fall back to AppleScript file URL reads when the macOS `_native` pasteboard module cannot be imported.
- Add macOS Command+Shift keymap variants while keeping the existing Ctrl+Shift bindings.
- Guard UI panel and import/export preference reads when `get_pref()` is unavailable.

## Validation

- `python3 -m py_compile` on the changed Python modules.
- Real Blender 5.1.2 GUI validation on macOS with real PNG/TIFF clipboard pixels:
  - `Command+Shift+V` opens `Super Import Image`.
  - `Import as Nodes` visually creates an `Image Texture` node in Geometry Nodes.
  - Terminal output showed no Python traceback after the final fix.
- Blender probe validation confirmed expected node types:
  - Shader: `ShaderNodeTexImage`
  - World: `ShaderNodeTexEnvironment`
  - Geometry: `GeometryNodeImageTexture`
  - Compositor: `CompositorNodeImage`
- Blender Python validation confirmed `MacClipboard().pull()` no longer raises the `_native` ImportError and returns a list.

## Notes

The visual clipboard test was performed on macOS because that is the available local GUI environment. The dispatch, node creation, preference guards, and Blender-first paste behavior are not macOS-specific.
