### PR TITLE
Fix Houdini clipboard file-drop Unicode handling

### DIFF
--- a/third_party_addons/Super IO for Houdini v0.3/_scripts_/houdini_spio_import.py
+++ b/third_party_addons/Super IO for Houdini v0.3/_scripts_/houdini_spio_import.py
@@ -10,8 +10,6 @@ import sys
 import ctypes
 import ctypes.wintypes as w
 
-from locale import getdefaultlocale
-
 import hou
 import numpy as np
 
@@ -43,7 +41,7 @@ def main():
         return print("Not Support this platform!")
 
     clipboard = WintypesClipboard()
-    file_list = clipboard.pull(force_unicode=FORCE_UNICORE)
+    file_list = clipboard.pull(force_unicode=FORCE_UNICORE) or []
     del clipboard  # release clipboard
 
     if len(file_list) == 0:
@@ -98,9 +96,9 @@ class WintypesClipboard():
         self.file_urls = file_urls
 
         self.CF_HDROP = 15
+        self.DRAG_QUERY_FILE_COUNT = 0xFFFFFFFF
 
         u32 = ctypes.windll.user32
-        k32 = ctypes.windll.kernel32
         s32 = ctypes.windll.shell32
 
         self.OpenClipboard = u32.OpenClipboard
@@ -117,27 +115,36 @@ class WintypesClipboard():
         self.CloseClipboard.argtypes = None
         self.CloseClipboard.restype = w.BOOL
 
-        self.DragQueryFile = s32.DragQueryFile
-        self.DragQueryFile.argtypes = [w.HANDLE, w.UINT, ctypes.c_void_p, w.UINT]
+        self.DragQueryFile = s32.DragQueryFileW
+        self.DragQueryFile.argtypes = [w.HANDLE, w.UINT, w.LPWSTR, w.UINT]
+        self.DragQueryFile.restype = w.UINT
 
     def pull(self, force_unicode=False):
         self.file_urls = []
 
-        if self.OpenClipboard(None):
-            h_hdrop = self.GetClipboardData(self.CF_HDROP)
+        opened = False
+        try:
+            if self.OpenClipboard(None):
+                opened = True
+                h_hdrop = self.GetClipboardData(self.CF_HDROP)
 
-            if h_hdrop:
-                # expose force unicode to preferences(if enabled unicode beta setting)
-                FS_ENCODING = getdefaultlocale()[1] if not force_unicode else 'utf-8'
-                file_count = self.DragQueryFile(h_hdrop, -1, None, 0)
+                if h_hdrop:
+                    file_count = self.DragQueryFile(h_hdrop, self.DRAG_QUERY_FILE_COUNT, None, 0)
 
-                for index in range(file_count):
-                    buf = ctypes.c_buffer(260)
-                    self.DragQueryFile(h_hdrop, index, buf, ctypes.sizeof(buf))
-                    self.file_urls.append(buf.value.decode(FS_ENCODING))
+                    for index in range(file_count):
+                        length = self.DragQueryFile(h_hdrop, index, None, 0)
+                        if length == 0:
+                            continue
+                        buf = ctypes.create_unicode_buffer(length + 1)
+                        self.DragQueryFile(h_hdrop, index, buf, length + 1)
+                        self.file_urls.append(buf.value)
 
-        self.CloseClipboard()
-        return self.file_urls
+            return self.file_urls
+        except (OSError, ctypes.ArgumentError):
+            return []
+        finally:
+            if opened:
+                self.CloseClipboard()
 
 
 main()

--- a/third_party_addons/Super IO for Houdini v0.3/toolbar/SPIO.shelf
+++ b/third_party_addons/Super IO for Houdini v0.3/toolbar/SPIO.shelf
@@ -222,8 +222,6 @@ import sys
 import ctypes
 import ctypes.wintypes as w
 
-from locale import getdefaultlocale
-
 import hou
 import numpy as np
 
@@ -255,7 +253,7 @@ def main():
         return print("Not Support this platform!")
 
     clipboard = WintypesClipboard()
-    file_list = clipboard.pull(force_unicode=FORCE_UNICORE)
+    file_list = clipboard.pull(force_unicode=FORCE_UNICORE) or []
     del clipboard  # release clipboard
 
     if len(file_list) == 0:
@@ -310,9 +308,9 @@ class WintypesClipboard():
         self.file_urls = file_urls
 
         self.CF_HDROP = 15
+        self.DRAG_QUERY_FILE_COUNT = 0xFFFFFFFF
 
         u32 = ctypes.windll.user32
-        k32 = ctypes.windll.kernel32
         s32 = ctypes.windll.shell32
 
         self.OpenClipboard = u32.OpenClipboard
@@ -329,27 +327,36 @@ class WintypesClipboard():
         self.CloseClipboard.argtypes = None
         self.CloseClipboard.restype = w.BOOL
 
-        self.DragQueryFile = s32.DragQueryFile
-        self.DragQueryFile.argtypes = [w.HANDLE, w.UINT, ctypes.c_void_p, w.UINT]
+        self.DragQueryFile = s32.DragQueryFileW
+        self.DragQueryFile.argtypes = [w.HANDLE, w.UINT, w.LPWSTR, w.UINT]
+        self.DragQueryFile.restype = w.UINT
 
     def pull(self, force_unicode=False):
         self.file_urls = []
 
-        if self.OpenClipboard(None):
-            h_hdrop = self.GetClipboardData(self.CF_HDROP)
+        opened = False
+        try:
+            if self.OpenClipboard(None):
+                opened = True
+                h_hdrop = self.GetClipboardData(self.CF_HDROP)
 
-            if h_hdrop:
-                # expose force unicode to preferences(if enabled unicode beta setting)
-                FS_ENCODING = getdefaultlocale()[1] if not force_unicode else 'utf-8'
-                file_count = self.DragQueryFile(h_hdrop, -1, None, 0)
+                if h_hdrop:
+                    file_count = self.DragQueryFile(h_hdrop, self.DRAG_QUERY_FILE_COUNT, None, 0)
 
-                for index in range(file_count):
-                    buf = ctypes.c_buffer(260)
-                    self.DragQueryFile(h_hdrop, index, buf, ctypes.sizeof(buf))
-                    self.file_urls.append(buf.value.decode(FS_ENCODING))
+                    for index in range(file_count):
+                        length = self.DragQueryFile(h_hdrop, index, None, 0)
+                        if length == 0:
+                            continue
+                        buf = ctypes.create_unicode_buffer(length + 1)
+                        self.DragQueryFile(h_hdrop, index, buf, length + 1)
+                        self.file_urls.append(buf.value)
 
-        self.CloseClipboard()
-        return self.file_urls
+            return self.file_urls
+        except (OSError, ctypes.ArgumentError):
+            return []
+        finally:
+            if opened:
+                self.CloseClipboard()
 
 
 main()


### PR DESCRIPTION
## Summary
- Update the Houdini import script to read `CF_HDROP` paths through `DragQueryFileW` with Unicode buffers.
- Remove locale-based decoding and fixed-size ANSI buffers so non-ASCII and long file paths are handled correctly.
- Keep the shelf tool copy in sync with the script version and make clipboard failure return an empty list safely.

## Testing
- Parsed both Houdini Python scripts with `ast` to confirm the updated code is syntactically valid.
- Verified the change is limited to the Houdini clipboard import path and the duplicated shelf script.